### PR TITLE
[CFRS-97] 네임 리팩토링 및 안정성 개선

### DIFF
--- a/src/model/Peer.ts
+++ b/src/model/Peer.ts
@@ -5,15 +5,15 @@ import { Consumer } from "mediasoup/node/lib/Consumer";
 
 export class Peer {
 
-  private _producerTransport: Transport | undefined = undefined;
-  private _consumerTransports: Transport[] = [];
+  private _sendTransport: Transport | undefined = undefined;
+  private _receiveTransports: Transport[] = [];
   private _producers: Producer[] = [];
   private _consumers: Consumer[] = [];
 
   public constructor(
     private readonly _uid: string,
     private readonly _socket: Socket,
-    private readonly _name: string,
+    private readonly _name: string
   ) {
   }
 
@@ -33,20 +33,20 @@ export class Peer {
     this._socket.emit(protocol, args, callback);
   };
 
-  public get producerTransport(): Transport | undefined {
-    return this._producerTransport;
+  public get sendTransport(): Transport | undefined {
+    return this._sendTransport;
   }
 
   public addTransport = (transport: Transport, isConsumer: boolean) => {
     if (isConsumer) {
-      this._consumerTransports = [...this._consumerTransports, transport];
+      this._receiveTransports = [...this._receiveTransports, transport];
     } else {
-      this._producerTransport = transport;
+      this._sendTransport = transport;
     }
   };
 
-  public findConsumerTransportBy = (id: string): Transport | undefined => {
-    return this._consumerTransports.find((transport) => {
+  public findReceiveTransportBy = (id: string): Transport | undefined => {
+    return this._receiveTransports.find((transport) => {
       return transport.id === id;
     });
   };
@@ -103,7 +103,7 @@ export class Peer {
   public dispose = () => {
     this._consumers.forEach((consumer: Consumer) => consumer.close());
     this._producers.forEach((producer: Producer) => producer.close());
-    this._consumerTransports.forEach((transport: Transport) => transport.close());
-    this._producerTransport?.close();
+    this._receiveTransports.forEach((transport: Transport) => transport.close());
+    this._sendTransport?.close();
   };
 }

--- a/src/model/Peer.ts
+++ b/src/model/Peer.ts
@@ -39,7 +39,10 @@ export class Peer {
 
   public addTransport = (transport: Transport, isConsumer: boolean) => {
     if (isConsumer) {
-      this._receiveTransports = [...this._receiveTransports, transport];
+      console.log("Added:",this._receiveTransports.length)
+      transport.observer.on("close", () => {
+        this._receiveTransports = this._receiveTransports.filter((t) => t.id !== transport.id);
+      });
     } else {
       this._sendTransport = transport;
     }

--- a/src/service/room_service.ts
+++ b/src/service/room_service.ts
@@ -54,6 +54,7 @@ export class RoomService {
     };
   };
 
+  // TODO: 이미 방에 접속한 경우도 체크하기
   canJoinRoom = async (
     userId: string,
     roomId: string,
@@ -183,24 +184,24 @@ export class RoomService {
     return transport;
   };
 
-  connectProducerTransport = (
+  connectSendTransport = (
     socketId: string,
     dtlsParameters: DtlsParameters
   ) => {
-    const producerTransport = this.findProducerTransportBy(socketId);
-    producerTransport?.connect({ dtlsParameters });
+    const sendTransport = this.findSendTransportBy(socketId);
+    sendTransport?.connect({ dtlsParameters });
   };
 
-  connectConsumerTransport = (
+  connectReceiveTransport = (
     socketId: string,
-    consumerTransportId: string,
+    receiveTransportId: string,
     dtlsParameters: DtlsParameters
   ) => {
-    const consumerTransport = this.findConsumerTransportBy(
+    const receiveTransport = this.findReceiveTransportBy(
       socketId,
-      consumerTransportId
+      receiveTransportId
     );
-    consumerTransport?.connect({ dtlsParameters });
+    receiveTransport?.connect({ dtlsParameters });
   };
 
   closeVideoProducer = (socketId: string) => {
@@ -228,20 +229,20 @@ export class RoomService {
     return room?.findOthersProducerIds(requesterSocketId) ?? [];
   };
 
-  findProducerTransportBy = (socketId: string): Transport | undefined => {
+  findSendTransportBy = (socketId: string): Transport | undefined => {
     const peer = this._roomRepository.findPeerBy(socketId);
-    return peer?.producerTransport;
+    return peer?.sendTransport;
   };
 
-  findConsumerTransportBy = (
+  findReceiveTransportBy = (
     socketId: string,
-    consumerTransportId: string
+    receiveTransportId: string
   ): Transport | undefined => {
     const peer = this._roomRepository.findPeerBy(socketId);
     if (peer === undefined) {
       return;
     }
-    return peer.findConsumerTransportBy(consumerTransportId);
+    return peer.findReceiveTransportBy(receiveTransportId);
   };
 
   resumeConsumer = async (socketId: string, consumerId: string) => {
@@ -264,11 +265,11 @@ export class RoomService {
     socketId: string,
     options: ProducerOptions
   ): Promise<Producer | undefined> => {
-    const producerTransport = roomService.findProducerTransportBy(socketId);
-    if (producerTransport === undefined) {
+    const sendTransport = this.findSendTransportBy(socketId);
+    if (sendTransport === undefined) {
       return undefined;
     }
-    const producer = await producerTransport.produce(options);
+    const producer = await sendTransport.produce(options);
     const peer = this._roomRepository.findPeerBy(socketId);
     if (peer === undefined) {
       producer.close();
@@ -290,18 +291,18 @@ export class RoomService {
   createConsumer = async (
     socketId: string,
     producerId: string,
-    consumerTransportId: string,
+    receiveTransportId: string,
     rtpCapabilities: RtpCapabilities
   ): Promise<Consumer | undefined> => {
     const router = roomService.findRoomRouterBy(socketId);
     if (router === undefined) {
       return undefined;
     }
-    const consumerTransport = roomService.findConsumerTransportBy(
+    const receiveTransport = roomService.findReceiveTransportBy(
       socketId,
-      consumerTransportId
+      receiveTransportId
     );
-    if (consumerTransport === undefined) {
+    if (receiveTransport === undefined) {
       return undefined;
     }
     const canConsume = router.canConsume({
@@ -309,7 +310,7 @@ export class RoomService {
       rtpCapabilities
     });
     if (canConsume) {
-      const consumer = await consumerTransport.consume({
+      const consumer = await receiveTransport.consume({
         producerId: producerId,
         rtpCapabilities,
         paused: true

--- a/src/service/room_service.ts
+++ b/src/service/room_service.ts
@@ -296,14 +296,14 @@ export class RoomService {
   ): Promise<Consumer | undefined> => {
     const router = roomService.findRoomRouterBy(socketId);
     if (router === undefined) {
-      return undefined;
+      throw Error("router를 찾을 수 없습니다.")
     }
     const receiveTransport = roomService.findReceiveTransportBy(
       socketId,
       receiveTransportId
     );
     if (receiveTransport === undefined) {
-      return undefined;
+      throw Error("receiveTransport가 없어 consumer를 만들 수 없습니다.")
     }
     const canConsume = router.canConsume({
       producerId: producerId,
@@ -326,16 +326,14 @@ export class RoomService {
     return undefined;
   };
 
-  removeConsumerAndNotify = (
+  removeConsumer = (
     socketId: string,
     consumer: Consumer,
-    remoteProducerId: string
   ) => {
     const peer = this._roomRepository.findPeerBy(socketId);
     if (peer === undefined) {
       return;
     }
-    peer.emit(protocol.PRODUCER_CLOSED, { remoteProducerId });
     peer.removeConsumer(consumer);
   };
 
@@ -438,16 +436,6 @@ const createWebRtcTransport = async (
         webRtcTransport_options
       );
       console.log(`transport id: ${transport.id}`);
-
-      transport.on("dtlsstatechange", (dtlsState) => {
-        if (dtlsState === "closed") {
-          transport.close();
-        }
-      });
-
-      transport.on("@close", () => {
-        console.log("transport closed");
-      });
 
       resolve(transport);
     } catch (error) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -232,7 +232,8 @@ export const handleConnect = async (socket: Socket) => {
         });
         consumer.on("producerclose", () => {
           console.log("producer of consumer closed");
-          roomService.removeConsumerAndNotify(socket.id, consumer, remoteProducerId);
+          roomService.removeConsumer(socket.id, consumer);
+          socket.emit(protocol.PRODUCER_CLOSED, { remoteProducerId });
         });
       } catch (error: any) {
         console.log(error.message);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -180,7 +180,7 @@ export const handleConnect = async (socket: Socket) => {
     protocol.TRANSPORT_PRODUCER_CONNECT,
     ({ dtlsParameters }: { dtlsParameters: DtlsParameters }) => {
       console.log("DTLS PARAMS... ", { dtlsParameters });
-      roomService.connectProducerTransport(socket.id, dtlsParameters);
+      roomService.connectSendTransport(socket.id, dtlsParameters);
     }
   );
 
@@ -190,11 +190,11 @@ export const handleConnect = async (socket: Socket) => {
       {
         rtpCapabilities,
         remoteProducerId,
-        serverConsumerTransportId
+        serverReceiveTransportId
       }: {
         rtpCapabilities: RtpCapabilities;
         remoteProducerId: string;
-        serverConsumerTransportId: string;
+        serverReceiveTransportId: string;
       },
       callback: (data: {
         // TODO: media-soup에 존자해는 타입으로 변환하기
@@ -211,7 +211,7 @@ export const handleConnect = async (socket: Socket) => {
         const consumer = await roomService.createConsumer(
           socket.id,
           remoteProducerId,
-          serverConsumerTransportId,
+          serverReceiveTransportId,
           rtpCapabilities
         );
         if (consumer === undefined) {
@@ -247,12 +247,12 @@ export const handleConnect = async (socket: Socket) => {
     protocol.TRANSPORT_RECEIVER_CONNECT,
     async ({
              dtlsParameters,
-             serverConsumerTransportId
+             serverReceiveTransportId
            }: {
       dtlsParameters: DtlsParameters;
-      serverConsumerTransportId: string;
+      serverReceiveTransportId: string;
     }) => {
-      roomService.connectConsumerTransport(socket.id, serverConsumerTransportId, dtlsParameters);
+      roomService.connectReceiveTransport(socket.id, serverReceiveTransportId, dtlsParameters);
     }
   );
 


### PR DESCRIPTION
- 함수 및 변수 send/receiveTransport로 정정
- 다른 피어를 통해 연결된 ReceiveTransport가 이미 존재한다면 다시 만들지 않도록 수정
- 피어가 사라질 때 해당 피어와 연결된 ReceiveTransport를 배열에서 제거하지 않던 문제 수정