### PR TITLE
타이머 이미 시작했을 때 다시 시작할 수 없도록 수정 및 이벤트 시간 버그 수정

### DIFF
--- a/src/model/PomodoroTimer.ts
+++ b/src/model/PomodoroTimer.ts
@@ -81,12 +81,13 @@ export class PomodoroTimer extends PomodoroTimerObservable {
     return this._property;
   }
 
-  public start = () => {
+  public start = (): boolean => {
     if (this._timeout != null) {
-      return;
+      return false;
     }
     this._startedAt = convertToKoreaDate(new Date());
     this._startFocusTimer();
+    return true;
   };
 
   private _startFocusTimer = () => {

--- a/src/model/PomodoroTimer.ts
+++ b/src/model/PomodoroTimer.ts
@@ -58,7 +58,7 @@ abstract class PomodoroTimerObservable {
 }
 
 export class PomodoroTimer extends PomodoroTimerObservable {
-  private _startedAt?: Date;
+  private _eventDate?: Date;
   private _timeout?: NodeJS.Timeout;
   private _shortBreakCount: number = 0;
   private _state = PomodoroTimerState.STOPPED;
@@ -73,8 +73,8 @@ export class PomodoroTimer extends PomodoroTimerObservable {
     return this._state;
   }
 
-  public get startedDate(): Date | undefined {
-    return this._startedAt;
+  public get eventDate(): Date | undefined {
+    return this._eventDate;
   }
 
   public get property(): PomodoroTimerProperty {
@@ -85,13 +85,17 @@ export class PomodoroTimer extends PomodoroTimerObservable {
     if (this._timeout != null) {
       return false;
     }
-    this._startedAt = convertToKoreaDate(new Date());
     this._startFocusTimer();
     return true;
   };
 
+  private _updateEventDate = () => {
+    this._eventDate = convertToKoreaDate(new Date());
+  }
+
   private _startFocusTimer = () => {
     this._state = PomodoroTimerState.STARTED;
+    this._updateEventDate();
     super.notifyTimerStarted();
     this._timeout = this._setTimeoutInMinutes(this._property.timerLengthMinutes, () => {
       if (this._shortBreakCount === this._property.longBreakInterval - 1) {
@@ -106,6 +110,7 @@ export class PomodoroTimer extends PomodoroTimerObservable {
 
   private _startShortBreakTimer = () => {
     this._state = PomodoroTimerState.SHORT_BREAK;
+    this._updateEventDate();
     super.notifyShortBreakStarted();
     this._timeout = this._setTimeoutInMinutes(this._property.shortBreakMinutes, () => {
       this._startFocusTimer();
@@ -114,6 +119,7 @@ export class PomodoroTimer extends PomodoroTimerObservable {
 
   private _startLongBreakTimer = () => {
     this._state = PomodoroTimerState.LONG_BREAK;
+    this._updateEventDate();
     super.notifyLongBreakStarted();
     this._timeout = this._setTimeoutInMinutes(this._property.longBreakMinutes, () => {
       this._startFocusTimer();
@@ -152,6 +158,7 @@ export class PomodoroTimer extends PomodoroTimerObservable {
       clearTimeout(this._timeout);
       this._timeout = undefined;
     }
+    this._eventDate = undefined;
     this._state = PomodoroTimerState.STOPPED;
   };
 

--- a/src/model/Room.ts
+++ b/src/model/Room.ts
@@ -185,7 +185,10 @@ export class Room {
   };
 
   public startTimer = (observer: PomodoroTimerObserver) => {
-    this._pomodoroTimer.start();
+    const didStart = this._pomodoroTimer.start();
+    if (!didStart) {
+      return;
+    }
     this._pomodoroTimer.addObserver(observer);
     this.broadcastProtocol({ protocol: START_TIMER });
   };

--- a/src/model/Room.ts
+++ b/src/model/Room.ts
@@ -70,8 +70,8 @@ export class Room {
     return this._pomodoroTimer.state;
   }
 
-  public get timerStartedDate(): Date | undefined {
-    return this._pomodoroTimer.startedDate;
+  public get timerEventDate(): Date | undefined {
+    return this._pomodoroTimer.eventDate;
   }
 
   public get timerProperty(): PomodoroTimerProperty {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -107,7 +107,7 @@ export const handleConnect = async (socket: Socket) => {
         rtpCapabilities,
         peerStates: room.getPeerStates(),
         // ex: 2023-02-05T11:48:59.636Z
-        timerStartedDate: room.timerStartedDate?.toISOString(),
+        timerStartedDate: room.timerEventDate?.toISOString(),
         timerState: room.timerState,
         timerProperty: room.timerProperty
       });


### PR DESCRIPTION
- 클라이언트에서 실수로 타이머 시작 요청을 또 보내도 서버측에서 막도록 수정했습니다.
- 방 접속시 타이머 시작한 시간(이벤트 말고 아예 처음 시작 시간)을 보내버리는 오류를 수정했습니다. 수정 후에는 타이머 이벤트가 발생한 시간을 보냅니다.