### PR TITLE
Implement CI/CD

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,10 +2,6 @@ name: Build Application
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -42,6 +42,10 @@ jobs:
           push: true
           file: ./dockerfile
           tags: jja08111/camstudy-media-server:latest
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          IP_ADDRESS: ${{ secrets.AWS_SSH_IP_ADDRESS }}
+          PORT: ${{ secrets.PORT }}
       - name: Deploy to server
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,10 +1,6 @@
 name: Docker CI/CD script
 
 on:
-#  TODO: Remove below 3 lines when merge into main!!
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -38,11 +38,11 @@ jobs:
         with:
           push: true
           file: ./dockerfile
+          tags: jja08111/camstudy-media-server:latest
           build-args: |
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             IP_ADDRESS=${{ secrets.AWS_SSH_IP_ADDRESS }}
             PORT=${{ secrets.PORT }}
-          tags: jja08111/camstudy-media-server:latest
       - name: Deploy to server
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -54,8 +54,9 @@ jobs:
           script: |
             cd ~/camstudy-webrtc-server
             sudo docker login
-            sudo docker pull jja08111/camstudy-media-server:latest
+            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/camstudy-media-server:latest
             sudo docker stop camstudy_media_server
             sudo docker rm camstudy_media_server
-            sudo docker run -d --name camstudy_media_server -p 2000-2020:2000-2020 jja08111/camstudy-media-server:latest
+            sudo docker run -d --name camstudy_media_server -p 2000-2020:2000-2020 ${{ secrets.DOCKERHUB_USERNAME }}/camstudy-media-server:latest
+            sudo docker image prune -a -f
             echo "success";

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,0 +1,44 @@
+name: Docker CI/CD script
+
+on:
+#  TODO: Remove below 3 lines when merge into main!!
+  pull-request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: ./dockerfile
+          tags: foundy/media-server:latest

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -2,7 +2,7 @@ name: Docker CI/CD script
 
 on:
 #  TODO: Remove below 3 lines when merge into main!!
-  pull-request:
+  pull_request:
     branches:
       - main
   push:

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -33,15 +33,24 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+#          TODO: REMOVE THIS!!
+      - name: Debugging1
+        run: ls -al
+
+      - name: Access ENV
+        run: echo '${{ secrets.ENV }}' > ./.env
+
+
+          #          TODO: REMOVE THIS!!
+      - name: Debugging2
+        run: ls -al
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
           file: ./dockerfile
-          build-args: |
-            DATABASE_URL=${{ secrets.DATABASE_URL }}
-            IP_ADDRESS=${{ secrets.AWS_SSH_IP_ADDRESS }}
-            PORT=${{ secrets.PORT }}
           tags: jja08111/camstudy-media-server:latest
       - name: Deploy to server
         uses: appleboy/ssh-action@master

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -41,4 +41,4 @@ jobs:
         with:
           push: true
           file: ./dockerfile
-          tags: foundy/media-server:latest
+          tags: jja08111/camstudy:latest

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -33,24 +33,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-#          TODO: REMOVE THIS!!
-      - name: Debugging1
-        run: ls -al
-
-      - name: Access ENV
-        run: echo '${{ secrets.ENV }}' > ./.env
-
-
-          #          TODO: REMOVE THIS!!
-      - name: Debugging2
-        run: ls -al
-
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
           file: ./dockerfile
+          build-args: |
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            IP_ADDRESS=${{ secrets.AWS_SSH_IP_ADDRESS }}
+            PORT=${{ secrets.PORT }}
           tags: jja08111/camstudy-media-server:latest
       - name: Deploy to server
         uses: appleboy/ssh-action@master

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -25,9 +25,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
 
-    env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -41,11 +38,11 @@ jobs:
         with:
           push: true
           file: ./dockerfile
+          build-args: |
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            IP_ADDRESS=${{ secrets.AWS_SSH_IP_ADDRESS }}
+            PORT=${{ secrets.PORT }}
           tags: jja08111/camstudy-media-server:latest
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          IP_ADDRESS: ${{ secrets.AWS_SSH_IP_ADDRESS }}
-          PORT: ${{ secrets.PORT }}
       - name: Deploy to server
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -57,6 +57,7 @@ jobs:
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/camstudy-media-server:latest
             sudo docker stop camstudy_media_server
             sudo docker rm camstudy_media_server
-            sudo docker run -d --name camstudy_media_server -p 2000-2020:2000-2020 ${{ secrets.DOCKERHUB_USERNAME }}/camstudy-media-server:latest
+            sudo docker run -d --name camstudy_media_server -p 2000-2020:2000-2020 -p 3000:3000 \
+              ${{ secrets.DOCKERHUB_USERNAME }}/camstudy-media-server:latest
             sudo docker image prune -a -f
             echo "success";

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -41,4 +41,20 @@ jobs:
         with:
           push: true
           file: ./dockerfile
-          tags: jja08111/camstudy:latest
+          tags: jja08111/camstudy-media-server:latest
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_SSH_IP_ADDRESS }}
+          username: ${{ secrets.AWS_SSH_USERNAME }}
+          key: ${{ secrets.AWS_SSH_KEY }}
+          debug: true
+          port: 22
+          script: |
+            cd ~/camstudy-webrtc-server
+            sudo docker login
+            sudo docker pull jja08111/camstudy-media-server:latest
+            sudo docker stop camstudy_media_server
+            sudo docker rm camstudy_media_server
+            sudo docker run -d --name camstudy_media_server -p 2000-2020:2000-2020 jja08111/camstudy-media-server:latest
+            echo "success";

--- a/dockerfile
+++ b/dockerfile
@@ -7,6 +7,8 @@ ENV DATABASE_URL=$DATABASE_URL \
     IP_ADDRESS=$IP_ADDRESS \
     PORT=$PORT
 
+RUN echo $PORT
+
 WORKDIR /usr/src/app
 
 COPY ./ ./

--- a/dockerfile
+++ b/dockerfile
@@ -3,6 +3,10 @@ RUN apt-get -y update
 RUN apt-get -y install python3
 RUN apt-get -y install python3-pip
 
+ENV DATABASE_URL=$DATABASE_URL \
+    IP_ADDRESS=$IP_ADDRESS \
+    PORT=$PORT
+
 WORKDIR /usr/src/app
 
 COPY ./ ./

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,9 @@
 FROM node:17.1.0
+
+ARG DATABASE_URL
+ARG IP_ADDRESS
+ARG PORT
+
 RUN apt-get -y update
 RUN apt-get -y install python3
 RUN apt-get -y install python3-pip

--- a/dockerfile
+++ b/dockerfile
@@ -3,10 +3,6 @@ RUN apt-get -y update
 RUN apt-get -y install python3
 RUN apt-get -y install python3-pip
 
-ENV DATABASE_URL=$DATABASE_URL \
-    IP_ADDRESS=$IP_ADDRESS \
-    PORT=$PORT
-
 WORKDIR /usr/src/app
 
 COPY ./ ./

--- a/dockerfile
+++ b/dockerfile
@@ -4,15 +4,13 @@ ARG DATABASE_URL
 ARG IP_ADDRESS
 ARG PORT
 
-RUN apt-get -y update
-RUN apt-get -y install python3
-RUN apt-get -y install python3-pip
-
 ENV DATABASE_URL=$DATABASE_URL \
     IP_ADDRESS=$IP_ADDRESS \
     PORT=$PORT
 
-RUN echo $PORT
+RUN apt-get -y update
+RUN apt-get -y install python3
+RUN apt-get -y install python3-pip
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
자동 배포를 구현했습니다.

자동 배포 조건은 다음과 같습니다. 
- main 브런치에 커밋된 경우

따라서 이제부터는 이 레파지토리에서 main 브런치는 개발용이 아닌 운영용으로 사용될 것입니다. 이제 dev 브런치를 새로 만들어 개발용으로 사용할 것입니다. 개발용으로 어떻게 이용할지는 문서로 정리해놓겠습니다.

자동배포 프로세스는 아래와 같습니다.

1. main 브런치에 커밋
2. Github action이 돌아감
3. 도커 허브에 로그인
4. 도커 이미지 빌드
5. 도커 허브에 이미지 push
6. AWS ec2에 ssh 원격 접속
7. 원격 환경에서 도커 허브 로그인
8. 도커 허브에서 이미지 pull
9. 이전에 동작하던 컨테이너 종료 및 제거
10. 새로운 이미지로 컨테이너 실행
11. 이전 이미지 제거

주의할 점은 새로 실행할 때 이전 컨테이너가 제거되기 때문에 사용자에게 미리 공지를 하고 점검시간에 배포를 진행하여야 한다는 점입니다. 아니면 무중단 배포를 위한 다른 방법을 찾아야합니다.